### PR TITLE
[🛠️fix] User와 RefreshToken 엔티티를 1대1 관계로 변경

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     depends_on:
       - database
     env_file:
-      - ../waggle/.env
+      - .env
 
   database:
     image: mysql:latest

--- a/src/main/java/com/waggle/apis/auth/entity/RefreshToken.java
+++ b/src/main/java/com/waggle/apis/auth/entity/RefreshToken.java
@@ -1,5 +1,6 @@
 package com.waggle.apis.auth.entity;
 
+import com.waggle.apis.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -13,12 +14,13 @@ import java.util.UUID;
 @Table(name = "refresh_tokens")
 public class RefreshToken {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "refresh_tokens_id")
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    private UUID id;
 
-    @Column(name = "users_uuid", columnDefinition = "BINARY(16)", unique = true)
-    private UUID userId;
+    @OneToOne
+    @JoinColumn(name = "user_id", referencedColumnName = "id", unique = true, nullable = false)
+    private User user;
 
     @Column(name = "token", nullable = false)
     private String token;

--- a/src/main/java/com/waggle/apis/auth/entity/RefreshTokenRepository.java
+++ b/src/main/java/com/waggle/apis/auth/entity/RefreshTokenRepository.java
@@ -7,12 +7,12 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.UUID;
 
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    @Query("SELECT u FROM RefreshToken u WHERE u.userId = :userId")
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID> {
+    @Query("SELECT u FROM RefreshToken u WHERE u.user.id = :userId")
     RefreshToken findByUserId(UUID userId);
 
     @Transactional
     @Modifying
-    @Query("DELETE FROM RefreshToken u WHERE u.userId = :userId")
+    @Query("DELETE FROM RefreshToken u WHERE u.user.id = :userId")
     void deleteByUserId(UUID userId);
 }

--- a/src/main/java/com/waggle/apis/user/entity/User.java
+++ b/src/main/java/com/waggle/apis/user/entity/User.java
@@ -16,12 +16,9 @@ import java.util.UUID;
 @Table(name = "users")
 public class User {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "users_id")
-    private Long id;
-
-    @Column(name = "users_uuid", columnDefinition = "BINARY(16)", unique = true)
-    private UUID userId;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    private UUID id;
 
     @Column(name = "name", nullable = false, length = 5)
     private String name;

--- a/src/main/java/com/waggle/apis/user/entity/UserRepository.java
+++ b/src/main/java/com/waggle/apis/user/entity/UserRepository.java
@@ -8,8 +8,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public interface UserRepository extends JpaRepository<User,Long> {
-    @Query("SELECT u FROM User u WHERE u.userId = :userId")
+public interface UserRepository extends JpaRepository<User,UUID> {
+    @Query("SELECT u FROM User u WHERE u.id = :userId")
     Optional<User> findByUserId(UUID userId);
 
     User findByProviderId(String providerId);

--- a/src/main/java/com/waggle/auth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/waggle/auth/OAuth2LoginSuccessHandler.java
@@ -75,7 +75,6 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
             log.info("신규 유저입니다. 등록을 진행합니다.");
 
             user = User.builder()
-                    .userId(UUID.randomUUID())
                     .name(name)
                     .email(email)
                     .provider(provider)
@@ -85,7 +84,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         } else {
             // 기존 유저인 경우
             log.info("기존 유저입니다.");
-            refreshTokenRepository.deleteByUserId(existUser.getUserId());
+            refreshTokenRepository.deleteByUserId(existUser.getId());
             user = existUser;
         }
 
@@ -95,16 +94,16 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         log.info("PROVIDER_ID : {}", providerId);
 
         // 리프레쉬 토큰 발급 후 저장
-        String refreshToken = jwtUtil.generateRefreshToken(user.getUserId(), REFRESH_TOKEN_EXPIRATION_TIME);
+        String refreshToken = jwtUtil.generateRefreshToken(user.getId(), REFRESH_TOKEN_EXPIRATION_TIME);
 
         RefreshToken newRefreshToken = RefreshToken.builder()
-                .userId(user.getUserId())
+                .user(user)
                 .token(refreshToken)
                 .build();
         refreshTokenRepository.save(newRefreshToken);
 
         // 액세스 토큰 발급
-        String accessToken = jwtUtil.generateAccessToken(user.getUserId(), ACCESS_TOKEN_EXPIRATION_TIME);
+        String accessToken = jwtUtil.generateAccessToken(user.getId(), ACCESS_TOKEN_EXPIRATION_TIME);
 
         Cookie cookie = new Cookie("refresh_token", refreshToken);
         cookie.setHttpOnly(true);


### PR DESCRIPTION
# 📝 작업 내용

> User와 RefreshToken의 관계를 1대1로 설정하였고, id는 전부 UUID를 사용하도록 변경하였습니다.
