### PR TITLE
[🛠️ Refactor] 인증 객체 파라미터 리팩토링

### DIFF
--- a/src/main/java/com/waggle/config/RedisConfig.java
+++ b/src/main/java/com/waggle/config/RedisConfig.java
@@ -1,6 +1,7 @@
 package com.waggle.config;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -12,11 +13,17 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Slf4j
 public class RedisConfig {
 
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         log.info("Redis 연결중...");
         try {
-            LettuceConnectionFactory factory = new LettuceConnectionFactory("redis", 6379);
+            LettuceConnectionFactory factory = new LettuceConnectionFactory(host, port);
             factory.afterPropertiesSet();  // 연결 초기화
             log.info("Redis 연결 성공");
             return factory;

--- a/src/main/java/com/waggle/config/SecurityConfig.java
+++ b/src/main/java/com/waggle/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.waggle.config;
 import com.waggle.global.secure.filter.JwtAuthenticationFilter;
 import com.waggle.global.secure.oauth2.handler.OAuth2LoginFailureHandler;
 import com.waggle.global.secure.oauth2.handler.OAuth2LoginSuccessHandler;
+import com.waggle.global.secure.oauth2.service.CustomOAuth2UserService;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -24,6 +25,7 @@ public class SecurityConfig {
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     CorsConfigurationSource corsConfigurationSource() {
         return request -> {
@@ -44,14 +46,12 @@ public class SecurityConfig {
                 corsConfigurationSource())) // CORS 설정 추가
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(authorize ->
-                authorize
-                    .requestMatchers("/api/v1/auth/**").permitAll()
-                    .requestMatchers("/api/v1/users/**").authenticated()
-                    .anyRequest().permitAll()
+                authorize.requestMatchers("/**").permitAll()
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .oauth2Login(oauth -> // OAuth2 로그인 기능에 대한 여러 설정의 진입점
                 oauth
+                    .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                     .successHandler(oAuth2LoginSuccessHandler) // 로그인 성공 시 핸들러
                     .failureHandler(oAuth2LoginFailureHandler) // 로그인 실패 시 핸들러
             )

--- a/src/main/java/com/waggle/config/SecurityConfig.java
+++ b/src/main/java/com/waggle/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.waggle.config;
 
+import com.waggle.global.secure.filter.JwtAuthenticationFilter;
 import com.waggle.global.secure.oauth2.handler.OAuth2LoginFailureHandler;
 import com.waggle.global.secure.oauth2.handler.OAuth2LoginSuccessHandler;
 import java.util.Collections;
@@ -11,6 +12,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
@@ -21,6 +23,7 @@ public class SecurityConfig {
 
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     CorsConfigurationSource corsConfigurationSource() {
         return request -> {
@@ -42,8 +45,11 @@ public class SecurityConfig {
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(authorize ->
                 authorize
-                    .requestMatchers("/**").permitAll()
+                    .requestMatchers("/api/v1/auth/**").permitAll()
+                    .requestMatchers("/api/v1/users/**").authenticated()
+                    .anyRequest().permitAll()
             )
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .oauth2Login(oauth -> // OAuth2 로그인 기능에 대한 여러 설정의 진입점
                 oauth
                     .successHandler(oAuth2LoginSuccessHandler) // 로그인 성공 시 핸들러

--- a/src/main/java/com/waggle/domain/ApiV1Controller.java
+++ b/src/main/java/com/waggle/domain/ApiV1Controller.java
@@ -1,8 +1,0 @@
-package com.waggle.domain;
-
-import org.springframework.web.bind.annotation.RequestMapping;
-
-@RequestMapping("/api/v1")
-public abstract class ApiV1Controller {
-
-}

--- a/src/main/java/com/waggle/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/waggle/domain/auth/controller/AuthController.java
@@ -1,6 +1,5 @@
 package com.waggle.domain.auth.controller;
 
-import com.waggle.domain.ApiV1Controller;
 import com.waggle.domain.auth.dto.AccessTokenVo;
 import com.waggle.domain.auth.service.AuthService;
 import com.waggle.global.exception.JwtTokenException;
@@ -27,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
-public class AuthController extends ApiV1Controller {
+public class AuthController {
 
     private final AuthService authService;
 

--- a/src/main/java/com/waggle/domain/auth/service/AuthService.java
+++ b/src/main/java/com/waggle/domain/auth/service/AuthService.java
@@ -1,11 +1,8 @@
 package com.waggle.domain.auth.service;
 
 import com.waggle.domain.auth.dto.AccessTokenVo;
-import com.waggle.domain.user.entity.User;
 
 public interface AuthService {
-
-    User getCurrentUser();
 
     AccessTokenVo reissueAccessToken(String refreshToken);
 

--- a/src/main/java/com/waggle/domain/project/controller/ProjectApplyController.java
+++ b/src/main/java/com/waggle/domain/project/controller/ProjectApplyController.java
@@ -1,6 +1,5 @@
 package com.waggle.domain.project.controller;
 
-import com.waggle.domain.ApiV1Controller;
 import com.waggle.domain.project.ProjectInfo;
 import com.waggle.domain.project.dto.ProjectApplicationDto;
 import com.waggle.domain.project.dto.ProjectResponseDto;
@@ -41,9 +40,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "프로젝트 지원", description = "프로젝트 지원 관련 API")
 @RestController
-@RequestMapping("/projects")
+@RequestMapping("/api/v1/projects")
 @RequiredArgsConstructor
-public class ProjectApplyController extends ApiV1Controller {
+public class ProjectApplyController {
 
     private final ProjectService projectService;
     private final UserService userService;

--- a/src/main/java/com/waggle/domain/project/controller/ProjectBookmarkController.java
+++ b/src/main/java/com/waggle/domain/project/controller/ProjectBookmarkController.java
@@ -8,6 +8,7 @@ import com.waggle.global.response.BaseResponse;
 import com.waggle.global.response.ErrorResponse;
 import com.waggle.global.response.SuccessResponse;
 import com.waggle.global.response.swagger.ProjectsSuccessResponse;
+import com.waggle.global.secure.oauth2.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -21,6 +22,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -70,11 +72,12 @@ public class ProjectBookmarkController extends ApiV1Controller {
         )
     })
     public ResponseEntity<BaseResponse<Boolean>> toggleMyBookmark(
-        @PathVariable UUID projectId
+        @PathVariable UUID projectId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return SuccessResponse.of(
             ApiStatus._OK,
-            projectService.toggleCurrentUserBookmark(projectId)
+            projectService.toggleCurrentUserBookmark(projectId, userDetails.getUser())
         );
     }
 
@@ -107,10 +110,12 @@ public class ProjectBookmarkController extends ApiV1Controller {
             )
         )
     })
-    public ResponseEntity<BaseResponse<Set<ProjectResponseDto>>> fetchMyBookmarkProjects() {
+    public ResponseEntity<BaseResponse<Set<ProjectResponseDto>>> fetchMyBookmarkProjects(
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
         return SuccessResponse.of(
             ApiStatus._OK,
-            projectService.getCurrentUserBookmarkProjects().stream()
+            projectService.getCurrentUserBookmarkProjects(userDetails.getUser()).stream()
                 .map(projectService::getProjectInfoByProject)
                 .map(ProjectResponseDto::from)
                 .collect(Collectors.toSet())

--- a/src/main/java/com/waggle/domain/project/controller/ProjectBookmarkController.java
+++ b/src/main/java/com/waggle/domain/project/controller/ProjectBookmarkController.java
@@ -1,6 +1,5 @@
 package com.waggle.domain.project.controller;
 
-import com.waggle.domain.ApiV1Controller;
 import com.waggle.domain.project.dto.ProjectResponseDto;
 import com.waggle.domain.project.service.ProjectService;
 import com.waggle.global.response.ApiStatus;
@@ -31,9 +30,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "프로젝트 북마크", description = "프로젝트 북마크 관련 API")
 @RestController
-@RequestMapping("/projects/bookmark")
+@RequestMapping("/api/v1/projects/bookmark")
 @RequiredArgsConstructor
-public class ProjectBookmarkController extends ApiV1Controller {
+public class ProjectBookmarkController {
 
     private final ProjectService projectService;
 

--- a/src/main/java/com/waggle/domain/project/controller/ProjectMemberController.java
+++ b/src/main/java/com/waggle/domain/project/controller/ProjectMemberController.java
@@ -11,6 +11,7 @@ import com.waggle.global.response.ErrorResponse;
 import com.waggle.global.response.SuccessResponse;
 import com.waggle.global.response.swagger.ProjectSuccessResponse;
 import com.waggle.global.response.swagger.ProjectsSuccessResponse;
+import com.waggle.global.secure.oauth2.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -24,6 +25,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -119,11 +121,12 @@ public class ProjectMemberController extends ApiV1Controller {
     })
     public ResponseEntity<BaseResponse<Set<UserResponseDto>>> removeMember(
         @PathVariable UUID projectId,
-        @PathVariable UUID userId
+        @PathVariable UUID userId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return SuccessResponse.of(
             ApiStatus._OK,
-            projectService.removeMemberUser(projectId, userId).stream()
+            projectService.removeMemberUser(projectId, userId, userDetails.getUser()).stream()
                 .map(userService::getUserInfoByUser)
                 .map(UserResponseDto::from)
                 .collect(Collectors.toCollection(LinkedHashSet::new))
@@ -168,9 +171,10 @@ public class ProjectMemberController extends ApiV1Controller {
     })
     public ResponseEntity<BaseResponse<Set<UserResponseDto>>> delegateLeader(
         @PathVariable UUID projectId,
-        @PathVariable UUID userId
+        @PathVariable UUID userId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        projectService.delegateLeader(projectId, userId);
+        projectService.delegateLeader(projectId, userId, userDetails.getUser());
         return SuccessResponse.of(ApiStatus._OK, null);
     }
 
@@ -203,8 +207,11 @@ public class ProjectMemberController extends ApiV1Controller {
             )
         )
     })
-    public ResponseEntity<BaseResponse<Object>> quitMyProject(@PathVariable UUID projectId) {
-        projectService.withdrawFromProject(projectId);
+    public ResponseEntity<BaseResponse<Object>> quitMyProject(
+        @PathVariable UUID projectId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        projectService.withdrawFromProject(projectId, userDetails.getUser());
         return SuccessResponse.of(ApiStatus._NO_CONTENT, null);
     }
 
@@ -230,10 +237,12 @@ public class ProjectMemberController extends ApiV1Controller {
             )
         )
     })
-    public ResponseEntity<BaseResponse<Set<ProjectResponseDto>>> fetchMyProjects() {
+    public ResponseEntity<BaseResponse<Set<ProjectResponseDto>>> fetchMyProjects(
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
         return SuccessResponse.of(
             ApiStatus._OK,
-            projectService.getCurrentUserProjects().stream()
+            projectService.getCurrentUserProjects(userDetails.getUser()).stream()
                 .map(projectService::getProjectInfoByProject)
                 .map(ProjectResponseDto::from)
                 .collect(Collectors.toCollection(LinkedHashSet::new))

--- a/src/main/java/com/waggle/domain/project/controller/ProjectMemberController.java
+++ b/src/main/java/com/waggle/domain/project/controller/ProjectMemberController.java
@@ -1,6 +1,5 @@
 package com.waggle.domain.project.controller;
 
-import com.waggle.domain.ApiV1Controller;
 import com.waggle.domain.project.dto.ProjectResponseDto;
 import com.waggle.domain.project.service.ProjectService;
 import com.waggle.domain.user.dto.UserResponseDto;
@@ -35,9 +34,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "프로젝트 멤버", description = "프로젝트 멤버 관련 API")
 @RestController
-@RequestMapping("/projects/member")
+@RequestMapping("/api/v1/projects/member")
 @RequiredArgsConstructor
-public class ProjectMemberController extends ApiV1Controller {
+public class ProjectMemberController {
 
     private final ProjectService projectService;
     private final UserService userService;

--- a/src/main/java/com/waggle/domain/project/controller/ProjectPostController.java
+++ b/src/main/java/com/waggle/domain/project/controller/ProjectPostController.java
@@ -1,6 +1,5 @@
 package com.waggle.domain.project.controller;
 
-import com.waggle.domain.ApiV1Controller;
 import com.waggle.domain.project.ProjectInfo;
 import com.waggle.domain.project.dto.ProjectInputDto;
 import com.waggle.domain.project.dto.ProjectResponseDto;
@@ -37,9 +36,9 @@ import org.springframework.web.bind.annotation.RestController;
 //put은 전체 다 수정, patch는 일부만 수정
 @Tag(name = "프로젝트 모집 게시글", description = "프로젝트 모집 게시글 관련 API")
 @RestController
-@RequestMapping("/projects/post")
+@RequestMapping("/api/v1/projects/post")
 @RequiredArgsConstructor
-public class ProjectPostController extends ApiV1Controller {
+public class ProjectPostController {
 
     private final ProjectService projectService;
 

--- a/src/main/java/com/waggle/domain/project/controller/ProjectPostController.java
+++ b/src/main/java/com/waggle/domain/project/controller/ProjectPostController.java
@@ -11,6 +11,7 @@ import com.waggle.global.response.BaseResponse;
 import com.waggle.global.response.ErrorResponse;
 import com.waggle.global.response.SuccessResponse;
 import com.waggle.global.response.swagger.ProjectSuccessResponse;
+import com.waggle.global.secure.oauth2.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -22,6 +23,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -95,9 +97,10 @@ public class ProjectPostController extends ApiV1Controller {
         )
     })
     public ResponseEntity<BaseResponse<ProjectResponseDto>> createProject(
-        @Valid @RequestBody ProjectInputDto projectInputDto
+        @Valid @RequestBody ProjectInputDto projectInputDto,
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Project project = projectService.createProject(projectInputDto);
+        Project project = projectService.createProject(projectInputDto, userDetails.getUser());
         ProjectInfo projectInfo = projectService.getProjectInfoByProject(project);
         return SuccessResponse.of(ApiStatus._CREATED, ProjectResponseDto.from(projectInfo));
     }
@@ -140,9 +143,14 @@ public class ProjectPostController extends ApiV1Controller {
     })
     public ResponseEntity<BaseResponse<ProjectResponseDto>> updateProject(
         @PathVariable UUID projectId,
-        @Valid @RequestBody ProjectInputDto projectInputDto
+        @Valid @RequestBody ProjectInputDto projectInputDto,
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Project project = projectService.updateProject(projectId, projectInputDto);
+        Project project = projectService.updateProject(
+            projectId,
+            projectInputDto,
+            userDetails.getUser()
+        );
         ProjectInfo projectInfo = projectService.getProjectInfoByProject(project);
         return SuccessResponse.of(ApiStatus._OK, ProjectResponseDto.from(projectInfo));
     }
@@ -181,8 +189,11 @@ public class ProjectPostController extends ApiV1Controller {
             )
         )
     })
-    public ResponseEntity<BaseResponse<Object>> deleteProject(@PathVariable UUID projectId) {
-        projectService.deleteProject(projectId);
+    public ResponseEntity<BaseResponse<Object>> deleteProject(
+        @PathVariable UUID projectId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        projectService.deleteProject(projectId, userDetails.getUser());
         return SuccessResponse.of(ApiStatus._NO_CONTENT, null);
     }
 }

--- a/src/main/java/com/waggle/domain/project/service/ProjectService.java
+++ b/src/main/java/com/waggle/domain/project/service/ProjectService.java
@@ -10,43 +10,43 @@ import java.util.UUID;
 
 public interface ProjectService {
 
-    Project createProject(ProjectInputDto projectInputDto);
+    Project createProject(ProjectInputDto projectInputDto, User user);
 
     Project getProjectById(UUID projectId);
 
     ProjectInfo getProjectInfoByProject(Project project);
 
-    Project updateProject(UUID projectId, ProjectInputDto projectInputDto);
+    Project updateProject(UUID projectId, ProjectInputDto projectInputDto, User user);
 
-    void deleteProject(UUID projectId);
+    void deleteProject(UUID projectId, User user);
 
     Set<User> getUsersByProjectId(UUID projectId);
 
     Set<User> getAppliedUsersByProjectId(UUID projectId);
 
-    Set<User> approveAppliedUser(UUID projectId, UUID userId);
+    Set<User> approveAppliedUser(UUID projectId, UUID userId, User user);
 
-    Set<User> rejectAppliedUser(UUID projectId, UUID userId);
+    Set<User> rejectAppliedUser(UUID projectId, UUID userId, User user);
 
-    Set<User> removeMemberUser(UUID projectId, UUID userId);
+    Set<User> removeMemberUser(UUID projectId, UUID userId, User user);
 
-    void delegateLeader(UUID projectId, UUID userId);
+    void delegateLeader(UUID projectId, UUID userId, User user);
 
     Set<Project> getUserProjects(UUID userId);
 
-    void withdrawFromProject(UUID projectId);
+    void withdrawFromProject(UUID projectId, User user);
 
     Set<Project> getUserBookmarkProjects(UUID userId);
 
-    Project applyProject(UUID projectId, ProjectApplicationDto projectApplicationDto);
+    Project applyProject(UUID projectId, ProjectApplicationDto projectApplicationDto, User user);
 
-    void cancelProjectApplication(UUID projectId);
+    void cancelProjectApplication(UUID projectId, User user);
 
-    Set<Project> getAppliedProjects();
+    Set<Project> getAppliedProjects(User user);
 
-    boolean toggleCurrentUserBookmark(UUID projectId);
+    boolean toggleCurrentUserBookmark(UUID projectId, User user);
 
-    Set<Project> getCurrentUserBookmarkProjects();
+    Set<Project> getCurrentUserBookmarkProjects(User user);
 
-    Set<Project> getCurrentUserProjects();
+    Set<Project> getCurrentUserProjects(User user);
 }

--- a/src/main/java/com/waggle/domain/reference/controller/ReferenceController.java
+++ b/src/main/java/com/waggle/domain/reference/controller/ReferenceController.java
@@ -1,6 +1,5 @@
 package com.waggle.domain.reference.controller;
 
-import com.waggle.domain.ApiV1Controller;
 import com.waggle.domain.reference.enums.Industry;
 import com.waggle.domain.reference.enums.IntroductionType;
 import com.waggle.domain.reference.enums.JobRole;
@@ -40,7 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "참조 데이터", description = "참조 데이터 관련 API")
 @RestController
 @RequiredArgsConstructor
-public class ReferenceController extends ApiV1Controller {
+public class ReferenceController {
 
     @GetMapping("/industries")
     @Operation(summary = "산업 분야 조회", description = "산업 분야를 전부 조회합니다.")

--- a/src/main/java/com/waggle/domain/user/controller/UserController.java
+++ b/src/main/java/com/waggle/domain/user/controller/UserController.java
@@ -1,7 +1,6 @@
 package com.waggle.domain.user.controller;
 
 import com.waggle.domain.ApiV1Controller;
-import com.waggle.domain.auth.service.AuthService;
 import com.waggle.domain.user.UserInfo;
 import com.waggle.domain.user.dto.UserInputDto;
 import com.waggle.domain.user.dto.UserResponseDto;
@@ -12,6 +11,7 @@ import com.waggle.global.response.BaseResponse;
 import com.waggle.global.response.ErrorResponse;
 import com.waggle.global.response.SuccessResponse;
 import com.waggle.global.response.swagger.UserSuccessResponse;
+import com.waggle.global.secure.oauth2.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -24,6 +24,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -39,7 +40,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class UserController extends ApiV1Controller {
 
-    private final AuthService authService;
     private final UserService userService;
 
     @GetMapping("/me")
@@ -64,9 +64,10 @@ public class UserController extends ApiV1Controller {
             )
         )
     })
-    public ResponseEntity<BaseResponse<UserResponseDto>> fetchMe() {
-        User user = authService.getCurrentUser();
-        UserInfo userInfo = userService.getUserInfoByUser(user);
+    public ResponseEntity<BaseResponse<UserResponseDto>> fetchMe(
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        UserInfo userInfo = userService.getUserInfoByUser(userDetails.getUser());
         return SuccessResponse.of(ApiStatus._OK, UserResponseDto.from(userInfo));
     }
 
@@ -94,9 +95,10 @@ public class UserController extends ApiV1Controller {
     })
     public ResponseEntity<BaseResponse<UserResponseDto>> updateMe(
         @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
-        @Valid @RequestPart(value = "updateUserDto") UserInputDto userInputDto
+        @Valid @RequestPart(value = "updateUserDto") UserInputDto userInputDto,
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        User user = userService.updateCurrentUser(profileImage, userInputDto);
+        User user = userService.updateUser(profileImage, userInputDto, userDetails.getUser());
         UserInfo userInfo = userService.getUserInfoByUser(user);
         return SuccessResponse.of(ApiStatus._OK, UserResponseDto.from(userInfo));
     }
@@ -111,8 +113,10 @@ public class UserController extends ApiV1Controller {
         @ApiResponse(responseCode = "204", description = "사용자 삭제 성공", content = @Content()),
         @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<BaseResponse<Object>> deleteMe() {
-        userService.deleteCurrentUser();
+    public ResponseEntity<BaseResponse<Object>> deleteMe(
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        userService.deleteUser(userDetails.getUser());
         return SuccessResponse.of(ApiStatus._NO_CONTENT, null);
     }
 

--- a/src/main/java/com/waggle/domain/user/controller/UserController.java
+++ b/src/main/java/com/waggle/domain/user/controller/UserController.java
@@ -1,6 +1,5 @@
 package com.waggle.domain.user.controller;
 
-import com.waggle.domain.ApiV1Controller;
 import com.waggle.domain.user.UserInfo;
 import com.waggle.domain.user.dto.UserInputDto;
 import com.waggle.domain.user.dto.UserResponseDto;
@@ -36,9 +35,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "사용자", description = "사용자 관련 API")
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
-public class UserController extends ApiV1Controller {
+public class UserController {
 
     private final UserService userService;
 

--- a/src/main/java/com/waggle/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/waggle/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.waggle.domain.user.repository;
 
 import com.waggle.domain.user.entity.User;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,5 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
 
-    User findByProviderId(String providerId);
+    Optional<User> findByProviderId(String providerId);
 }

--- a/src/main/java/com/waggle/domain/user/service/UserService.java
+++ b/src/main/java/com/waggle/domain/user/service/UserService.java
@@ -12,7 +12,7 @@ public interface UserService {
 
     UserInfo getUserInfoByUser(User user);
 
-    User updateCurrentUser(MultipartFile profileImage, UserInputDto userInputDto);
+    User updateUser(MultipartFile profileImage, UserInputDto userInputDto, User user);
 
-    void deleteCurrentUser();
+    void deleteUser(User user);
 }

--- a/src/main/java/com/waggle/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/waggle/domain/user/service/UserServiceImpl.java
@@ -82,9 +82,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public User updateCurrentUser(MultipartFile profileImage, UserInputDto userInputDto) {
-        User user = authService.getCurrentUser();
-
+    public User updateUser(MultipartFile profileImage, UserInputDto userInputDto, User user) {
         user.update(
             userInputDto.name(),
             getProfileImageUrl(profileImage, user),
@@ -106,8 +104,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public void deleteCurrentUser() {
-        User user = authService.getCurrentUser();
+    public void deleteUser(User user) {
         s3Service.deleteFile(user.getProfileImageUrl());
         userRepository.delete(user);
         userJobRoleRepository.deleteByUserId(user.getId());

--- a/src/main/java/com/waggle/global/secure/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/waggle/global/secure/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package com.waggle.global.secure.filter;
+
+import com.waggle.domain.user.entity.User;
+import com.waggle.domain.user.repository.UserRepository;
+import com.waggle.global.exception.JwtTokenException;
+import com.waggle.global.secure.jwt.JwtUtil;
+import com.waggle.global.secure.oauth2.CustomUserDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(
+        @NonNull HttpServletRequest request,
+        @NonNull HttpServletResponse response,
+        @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        try {
+            String authorizationHeader = request.getHeader("Authorization");
+            String token = jwtUtil.getTokenFromHeader(authorizationHeader);
+
+            if (jwtUtil.validateToken(token)) {
+                UUID userId = UUID.fromString(jwtUtil.getUserIdFromToken(token));
+                User user = userRepository.findById(userId).orElse(null);
+
+                if (user != null) {
+                    CustomUserDetails customUserDetails = new CustomUserDetails(null, user);
+                    Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        customUserDetails,
+                        null,
+                        Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"))
+                    );
+
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            }
+        } catch (JwtTokenException e) {
+            log.warn("JWT Token 예외: {}", e.getMessage());
+        } catch (Exception e) {
+            log.error("JWT 인증 과정에서 예상치 못한 예외 발생", e);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/waggle/global/secure/jwt/JwtUtil.java
+++ b/src/main/java/com/waggle/global/secure/jwt/JwtUtil.java
@@ -21,9 +21,9 @@ import org.springframework.stereotype.Component;
 public class JwtUtil {
 
     @Value("${JWT_ACCESS_TOKEN_EXPIRE_TIME}")
-    public static long accessTokenExpirationTime; // 액세스 토큰 유효기간
+    public long accessTokenExpirationTime; // 액세스 토큰 유효기간
     @Value("${JWT_REFRESH_TOKEN_EXPIRE_TIME}")
-    public static long refreshTokenExpirationTime; // 리프레쉬 토큰 유효기간
+    public long refreshTokenExpirationTime; // 리프레쉬 토큰 유효기간
     @Value("${JWT_SECRET_KEY}")
     private String secretKey;
 

--- a/src/main/java/com/waggle/global/secure/oauth2/CustomUserDetails.java
+++ b/src/main/java/com/waggle/global/secure/oauth2/CustomUserDetails.java
@@ -1,0 +1,65 @@
+package com.waggle.global.secure.oauth2;
+
+import com.waggle.domain.user.entity.User;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements OAuth2User, UserDetails {
+
+    private final OAuth2User oAuth2User;
+
+    @Getter
+    private final User user;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return oAuth2User != null ? oAuth2User.getAttributes() : Map.of();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return oAuth2User != null ? oAuth2User.getAuthorities() : Collections.emptyList();
+    }
+
+    @Override
+    public String getName() {
+        return user.getName();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/waggle/global/secure/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/waggle/global/secure/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,54 @@
+package com.waggle.global.secure.oauth2.service;
+
+import com.waggle.domain.user.entity.User;
+import com.waggle.domain.user.repository.UserRepository;
+import com.waggle.global.secure.oauth2.CustomUserDetails;
+import com.waggle.global.secure.oauth2.adapter.GoogleUserInfoAdapter;
+import com.waggle.global.secure.oauth2.adapter.KakaoUserInfoAdapter;
+import com.waggle.global.secure.oauth2.adapter.NaverUserInfoAdapter;
+import com.waggle.global.secure.oauth2.adapter.OAuth2UserInfo;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(
+        OAuth2UserRequest oAuth2UserRequest
+    ) throws OAuth2AuthenticationException {
+        OAuth2User oauth2User = super.loadUser(oAuth2UserRequest);
+
+        String registrationId = oAuth2UserRequest.getClientRegistration().getRegistrationId();
+        OAuth2UserInfo userInfo = switch (registrationId) {
+            case "google" -> new GoogleUserInfoAdapter(oauth2User.getAttributes());
+            case "kakao" -> new KakaoUserInfoAdapter(oauth2User.getAttributes());
+            case "naver" -> new NaverUserInfoAdapter(
+                (Map<String, Object>) oauth2User.getAttributes().get("response"));
+            default ->
+                throw new OAuth2AuthenticationException("Unsupported provider: " + registrationId);
+        };
+
+        String providerId = userInfo.getProviderId();
+        User user = userRepository.findByProviderId(providerId).orElseGet(() ->
+            userRepository.save(User.builder()
+                .provider(userInfo.getProvider())
+                .providerId(userInfo.getProviderId())
+                .profileImageUrl(userInfo.getProfileImage())
+                .name(userInfo.getName())
+                .email(userInfo.getEmail())
+                .build()
+            )
+        );
+
+        return new CustomUserDetails(oauth2User, user);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -112,6 +112,10 @@ springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
 
+logging:
+  level:
+    org.springframework.web: DEBUG
+
 cloud:
   aws:
     credentials:


### PR DESCRIPTION
# 📝 작업 내용

- [x]  인증 객체 클래스를 `@AuthenticationPrincipal`로 받을 수 있도록 수정
- [x]  `AuthService`에서 `getCurrentUser()` 제거
- [x] 서비스 레이어에서는 `User`가 아닌 `PrincipalDetails.getUser()`를 사용하여 로직 유지


# 💬 리뷰 요구사항

이전 `ApiV1Controller`를 추가하여 컨트롤러가 상속함으로써 매핑 경로를 concatenate 하도록 했으나, 경로가 오버라이딩 되어 의도한 대로 동작하지 않았습니다.

```java
@RequestMapping("/api/v1")
public abstract class ApiV1Controller { ... }

// 의도한 경로: /api/v1/users/...
// 실제 경로: /users/...
@RequestMapping("/users")
public class UserController extends ApiV1Controller { ... }
```

따라서 이전 구현대로 롤백했습니다.
컨트롤러마다 `"/api/v1"`를 붙이는 중복을 해결할 수 있긴 하나, 해결 방법이 중복으로 `"/api/v1"`를 쓰는 것보다 번거로운 배보다 배꼽이 더 큰 방법이라 기존대로 진행했습니다.

# 🔧 앞으로의 과제

- 인앱 알림 구현
- DTO 오버페칭 해결
- DB 제약 조건, 인덱스, 쿼리 최적화
- RESTful API
